### PR TITLE
add documentation

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -1,0 +1,33 @@
+# .readthedocs.yaml
+# Read the Docs configuration file
+# See https://docs.readthedocs.io/en/stable/config-file/v2.html for details
+
+# Required
+version: 2
+
+# Set the OS, Python version and other tools you might need
+build:
+  os: ubuntu-22.04
+  tools:
+    python: "3.10"  # Match the Python version used in your environment.yml
+
+# Build documentation in the "docs/" directory with Sphinx
+# This assumes you have a Sphinx conf.py file in the docs/ directory.
+# If not, you need to set up Sphinx and create a docs/ directory with a conf.py file.
+sphinx:
+  configuration: docs/conf.py
+
+# Optionally build your docs in additional formats such as PDF and ePub
+# formats:
+#    - pdf
+#    - epub
+
+# Optional but recommended, declare the Python requirements required
+# to build your documentation
+# Here we refer to a requirements.txt that should list all Python packages
+# necessary to build the documentation.
+# If you do not have one, consider creating it based on the Python dependencies
+# in environment.yml or just uncomment below lines and list them directly.
+python:
+  install:
+    - requirements: docs/requirements.txt

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,0 +1,20 @@
+# Minimal makefile for Sphinx documentation
+#
+
+# You can set these variables from the command line, and also
+# from the environment for the first two.
+SPHINXOPTS    ?=
+SPHINXBUILD   ?= sphinx-build
+SOURCEDIR     = .
+BUILDDIR      = _build
+
+# Put it first so that "make" without argument is like "make help".
+help:
+	@$(SPHINXBUILD) -M help "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)
+
+.PHONY: help Makefile
+
+# Catch-all target: route all unknown targets to Sphinx using the new
+# "make mode" option.  $(O) is meant as a shortcut for $(SPHINXOPTS).
+%: Makefile
+	@$(SPHINXBUILD) -M $@ "$(SOURCEDIR)" "$(BUILDDIR)" $(SPHINXOPTS) $(O)

--- a/docs/befor_run.rst
+++ b/docs/befor_run.rst
@@ -1,0 +1,18 @@
+Before you run
+--------------
+
+You have to download example climate data and NaturalEarth coastlines. To do it simply run:
+
+.. code-block:: bash
+
+    ./download_data.sh
+
+You also need to download the `natural hazard data <https://sedac.ciesin.columbia.edu/data/set/pend-gdis-1960-2018/data-download>`_ (for which you have to create a free account). Please download the **CSV - Disaster Location Centroids [zip file]** and unpack it into the 'data/natural_hazards' folder. Your file should automatically be called 'pend-gdis-1960-2018-disasterlocations.csv'. If not, please change the file name accordingly.
+
+You would also need an `OpenAI API key <https://platform.openai.com/docs/api-reference>`_ to run the prototype. You can provide it as environment variable:
+
+.. code-block:: bash
+
+    export OPENAI_API_KEY="???????"
+
+There is a possibility to also provide it in the running app. The cost of each request (status September 2023) is about 6 cents with `gpt-4` and about 0.3 cents with `gpt-3.5-turbo` (you can change it in the beginning of `climsight.py` script).

--- a/docs/citation.rst
+++ b/docs/citation.rst
@@ -1,0 +1,6 @@
+Citation
+========
+
+If you refer to or utilize ClimSight in your research or work, please cite this publication:
+
+Koldunov, N., Jung, T. Local climate services for all, courtesy of large language models. *Commun Earth Environ* **5**, 13 (2024). https://doi.org/10.1038/s43247-023-01199-1

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,0 +1,33 @@
+# Configuration file for the Sphinx documentation builder.
+#
+# For the full list of built-in configuration values, see the documentation:
+# https://www.sphinx-doc.org/en/master/usage/configuration.html
+
+# -- Project information -----------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#project-information
+
+import os
+import sys
+
+sys.path.insert(0, os.path.abspath("../src"))
+
+project = 'Climsight'
+copyright = '2024, Climsight contributors'
+author = 'Climsight contributors'
+release = '0.2.0'
+
+# -- General configuration ---------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
+
+extensions = ['sphinx.ext.autodoc', 'sphinx.ext.viewcode']
+
+templates_path = ['_templates']
+exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
+
+
+
+# -- Options for HTML output -------------------------------------------------
+# https://www.sphinx-doc.org/en/master/usage/configuration.html#options-for-html-output
+
+html_theme = 'sphinx_rtd_theme'
+html_static_path = ['_static']

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -1,0 +1,33 @@
+.. climsight documentation master file, created by
+   sphinx-quickstart on Fri Apr 19 19:02:03 2024.
+   You can adapt this file completely to your liking, but it should at least
+   contain the root `toctree` directive.
+
+Welcome to Climsight's Documentation
+============================================
+
+.. toctree::
+   :maxdepth: 2
+   :caption: Contents:
+
+   introduction
+   running_docker
+   installation
+   befor_run
+   running_src
+   citation
+
+Indices and tables
+==================
+
+* :ref:`genindex`
+* :ref:`modindex`
+* :ref:`search`
+
+
+Citation
+--------
+
+If you use or refer to ClimSight in your work, please cite the following publication:
+
+Koldunov, N., Jung, T. Local climate services for all, courtesy of large language models. *Commun Earth Environ* **5**, 13 (2024). https://doi.org/10.1038/s43247-023-01199-1

--- a/docs/installation.rst
+++ b/docs/installation.rst
@@ -1,0 +1,31 @@
+Installation
+============
+
+The easiest way is to install it through conda or mamba. We recommend mamba, as it's faster.
+
+`Install mamba <https://mamba.readthedocs.io/en/latest/mamba-installation.html#mamba-install>`_ if you don't have it.
+
+.. code-block:: bash
+
+    git clone https://github.com/koldunovn/climsight.git
+    cd climsight
+
+Create environment and install necessary packages:
+
+.. code-block:: bash
+
+    mamba env create -f environment.yml
+
+Activate the environment:
+
+.. code-block:: bash
+
+    conda activate climsight
+
+Climsight package installation
+
+.. code-block:: bash
+
+    pip install climsight
+
+For installation, use either pip alone for all packages and dependencies in a pure Python setup, or use mamba for dependencies followed by pip for Climsight in a Conda environment. Mixing package sources can lead to conflicts and is generally not recommended.

--- a/docs/introduction.rst
+++ b/docs/introduction.rst
@@ -1,0 +1,7 @@
+Introduction
+============
+
+Climate Foresight is a prototype of a system that answers questions about climate change impacts on planned human activities.
+
+.. image:: https://github.com/koldunovn/climsight/assets/3407313/bf7cd327-c8a9-4a09-bfb5-778269fcd15c
+   :alt: screencast

--- a/docs/make.bat
+++ b/docs/make.bat
@@ -1,0 +1,35 @@
+@ECHO OFF
+
+pushd %~dp0
+
+REM Command file for Sphinx documentation
+
+if "%SPHINXBUILD%" == "" (
+	set SPHINXBUILD=sphinx-build
+)
+set SOURCEDIR=.
+set BUILDDIR=_build
+
+%SPHINXBUILD% >NUL 2>NUL
+if errorlevel 9009 (
+	echo.
+	echo.The 'sphinx-build' command was not found. Make sure you have Sphinx
+	echo.installed, then set the SPHINXBUILD environment variable to point
+	echo.to the full path of the 'sphinx-build' executable. Alternatively you
+	echo.may add the Sphinx directory to PATH.
+	echo.
+	echo.If you don't have Sphinx installed, grab it from
+	echo.https://www.sphinx-doc.org/
+	exit /b 1
+)
+
+if "%1" == "" goto help
+
+%SPHINXBUILD% -M %1 %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+goto end
+
+:help
+%SPHINXBUILD% -M help %SOURCEDIR% %BUILDDIR% %SPHINXOPTS% %O%
+
+:end
+popd

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx==7.1.2
+sphinx-rtd-theme==1.3.0rc1

--- a/docs/running_docker.rst
+++ b/docs/running_docker.rst
@@ -1,0 +1,44 @@
+Running ClimSight with Docker
+================================
+
+**Running with Docker**
+Simplest way to run Climsight is to use Docker.
+There are several ways to run it using Docker:
+
+1. **Using a Pre-built Container**
+
+   .. code-block:: bash
+
+       docker pull koldunovn/climsight:stable
+       docker run -p 8501:8501 -e OPENAI_API_KEY=$OPENAI_API_KEY climsight
+
+   Access the system by navigating to `http://localhost:8501/` in your web browser.
+
+2. **Building and Running from Source**
+
+   Ensure you have `git`, `wget`, and `docker` installed, then execute:
+
+   .. code-block:: bash
+
+       git clone https://github.com/koldunovn/climsight.git
+       cd climsight
+       ./download_data.sh
+       docker build -t climsight .
+       docker run -p 8501:8501 climsight
+
+   If you don't want to add OpenAI key every time, you can expose it through:
+
+   .. code-block:: bash
+
+       docker run -p 8501:8501 -e OPENAI_API_KEY=$OPENAI_API_KEY climsight
+      
+   where $OPENAI_API_KEY not necessarily should be environment variable, you can insert the key directly.
+
+   If you do not have an OpenAI key but want to test Climsight without sending requests to OpenAI, you can run Climsight with the skipLLMCall argument:
+
+   If you don't want to add OpenAI key every time, you can expose it through:
+
+   .. code-block:: bash
+
+       docker run -p 8501:8501 -e STREAMLIT_ARGS="skipLLMCall" climsight
+

--- a/docs/running_src.rst
+++ b/docs/running_src.rst
@@ -1,0 +1,27 @@
+Running Climsight
+==================
+
+Change to the ``climsight`` folder:
+
+.. code-block:: bash
+
+    cd climsight
+    streamlit run src/climsight/climsight.py
+
+If you install climsight via pip, make sure to run it in the directory where the data folder has been downloaded:
+
+.. code-block:: bash
+
+    climsight
+
+The browser window should pop up, with the app running. Ask the questions and don't forget to press "Generate".
+
+.. image:: https://github.com/koldunovn/climsight/assets/3407313/569a4c38-a601-4014-b10d-bd34c59b91bb
+   :width: 800
+   :alt: Screenshot 2023-09-26 at 15 26 51
+
+If you do not have an OpenAI key but want to test Climsight without sending requests to OpenAI, you can run Climsight with the ``skipLLMCall`` argument:
+
+.. code-block:: bash
+
+    streamlit run src/climsight/climsight.py skipLLMCall


### PR DESCRIPTION
This is a very basic version of the **documentation**, essentially a copy of the README:
[https://climsight.readthedocs.io/en/latest/](https://climsight.readthedocs.io/en/latest/)

Currently, it does not include automatic completion for function and module references. Honestly, I'm frustrated with trying to integrate it; I can't figure out what's wrong with the package structure that prevents sphinx-autogen from picking it up.