### PR TITLE
fixing installation with micromamba

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -33,4 +33,7 @@ dependencies:
     - scipy
     - pyproj
     - reportlab
-    - aitta-client
+  # pip-only packages must go under this section:
+    - pip:
+      - aitta-client
+      - langchain_classic


### PR DESCRIPTION
Tried to install on a new machine. Get problems with `aitta-client` and `langchain_classic` not in the `conda-forge`. Solve it by installing with pip. Not sure if this is fine, please have a look.

