### PR TITLE
fix: catch protobuf TypeError on optional streamlit import

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,19 +73,28 @@ OPENAI_API_KEY="sk-..."
 ARRAYLAKE_API_KEY="your-arraylake-key"
 ```
 
-### 4. Start the FastAPI backend
-
-```bash
-uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload
-```
-
-The API runs on `http://localhost:8000`. Health check: `GET /health`.
-
-### 5. Start the React frontend
+### 4. Install frontend dependencies
 
 ```bash
 cd frontend
 npm install
+cd ..
+```
+
+> **Important:** Run `npm install` *before* starting the backend. If uvicorn is already running with `--reload`, the creation of `node_modules/` triggers a server restart, causing temporary `ETIMEDOUT` proxy errors in the frontend.
+
+### 5. Start the FastAPI backend
+
+```bash
+uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload --reload-exclude 'frontend/node_modules/*'
+```
+
+The API runs on `http://localhost:8000`. Health check: `GET /health`.
+
+### 6. Start the React frontend
+
+```bash
+cd frontend
 npm run dev
 ```
 

--- a/environment.yml
+++ b/environment.yml
@@ -69,7 +69,6 @@ dependencies:
 
     # pip-only packages (not available on conda-forge)
     - pip:
-        - langchain-classic
-        - langchain-anthropic
+        - langchain-anthropic<1.0.0
         - arraylake
         - aitta-client

--- a/src/climsight/tools/destine_retrieval_tool.py
+++ b/src/climsight/tools/destine_retrieval_tool.py
@@ -29,7 +29,7 @@ except ImportError:
 
 try:
     import streamlit as st
-except ImportError:
+except Exception:
     st = None
 
 logger = logging.getLogger(__name__)

--- a/src/climsight/tools/era5_retrieval_tool.py
+++ b/src/climsight/tools/era5_retrieval_tool.py
@@ -25,7 +25,7 @@ try:
     # Optional: Check for Streamlit to support session state if available
     try:
         import streamlit as st
-    except ImportError:
+    except Exception:
         st = None
 except ImportError as e:
     install_command = "pip install --upgrade xarray zarr arraylake pandas numpy pydantic langchain-core"


### PR DESCRIPTION
## Summary

- Broadened `except ImportError` to `except Exception` for optional `import streamlit` in `era5_retrieval_tool.py` and `destine_retrieval_tool.py`
- When running via FastAPI (uvicorn), streamlit is not needed but gets imported transitively. If the installed protobuf version is incompatible with streamlit's generated `_pb2.py` files, a `TypeError` is raised — not `ImportError` — which crashes the backend.
- These two files already treat streamlit as optional (`st = None` fallback), so catching any exception is the correct behavior.

## Test plan
- [ ] Run `uvicorn api.main:app --host 0.0.0.0 --port 8000 --reload` — no protobuf crash on startup
- [ ] Streamlit UI still works when run via `streamlit run src/climsight/climsight.py`